### PR TITLE
Branch pangrwa delete command

### DIFF
--- a/src/main/java/seedu/address/commons/core/Messages.java
+++ b/src/main/java/seedu/address/commons/core/Messages.java
@@ -8,6 +8,7 @@ public class Messages {
     public static final String MESSAGE_UNKNOWN_COMMAND = "Unknown command";
     public static final String MESSAGE_INVALID_COMMAND_FORMAT = "Invalid command format! \n%1$s";
     public static final String MESSAGE_INVALID_CLIENT_DISPLAYED_INDEX = "The client index provided is invalid";
+    public static final String MESSAGE_INVALID_POLICY_DISPLAYED_INDEX = "The policy index provided is invalid";
     public static final String MESSAGE_CLIENTS_LISTED_OVERVIEW = "%1$d clients listed!";
     public static final String MESSAGE_CANNOT_UNDO = "There is no more operations to undo!";
     public static final String MESSAGE_CANNOT_REDO = "There is no more operations to redo!";

--- a/src/main/java/seedu/address/logic/commands/AddPolicyCommand.java
+++ b/src/main/java/seedu/address/logic/commands/AddPolicyCommand.java
@@ -26,13 +26,13 @@ public class AddPolicyCommand extends Command {
     public static final String MESSAGE_USAGE = COMMAND_WORD + ": Adds a policy to a client in the program. "
             + "Parameters: "
             + "INDEX (must be a positive integer) "
-            + "POLICY (must be a valid policy)"
+            + "POLICY (must be a valid policy)\n"
             + "Example: " + COMMAND_WORD + " "
             + "1 "
-            + "pn/Fire Insurance"
-            + "d/01-01-2021 "
-            + "pr/1000"
-            + "fr/YEARLY";
+            + "pn/Fire Insurance "
+            + "pd/01.01.2021 "
+            + "pp/1000 "
+            + "pf/yearly";
 
     public final Index index;
     public final Policy policy;

--- a/src/main/java/seedu/address/logic/commands/DeletePolicyCommand.java
+++ b/src/main/java/seedu/address/logic/commands/DeletePolicyCommand.java
@@ -1,0 +1,90 @@
+package seedu.address.logic.commands;
+
+import static java.util.Objects.requireNonNull;
+import static seedu.address.commons.util.CollectionUtil.requireAllNonNull;
+
+import java.util.List;
+
+import seedu.address.commons.core.Messages;
+import seedu.address.commons.core.index.Index;
+import seedu.address.logic.commands.exceptions.CommandException;
+import seedu.address.model.Model;
+import seedu.address.model.client.Client;
+import seedu.address.model.client.policy.Policy;
+
+/**
+ * Deletes a policy identified using it's displayed index from the client that is identified using its displayed
+ * index from the address book.
+ */
+public class DeletePolicyCommand extends Command {
+    public static final String COMMAND_WORD = "deletePolicy";
+    public static final String MESSAGE_USAGE = COMMAND_WORD
+            + ": Deletes the policy from the client identified by the index number used in the displayed list and "
+            + ": the policy identified by the index number used in the displayed policy list associated"
+            + " associated to the client.\n"
+            + "Parameters: INDEX (must be a positive integer)\n"
+            + "Example: " + COMMAND_WORD + " 1" + " pi/1";
+    public static final String MESSAGE_DELETE_POLICY_SUCCESS = "Deleted Policy: %1$s";
+
+    public final Index clientIndex;
+    public final Index policyIndex;
+
+
+
+    /**
+     * Creates a DeletePolicyCommand to remove the specified {@code Policy} by the index displayed in the client policy
+     * list.
+     * @param clientIndex the client index displayed from the address book.
+     * @param policyIndex the policy index displayed from the client.
+     */
+    public DeletePolicyCommand(Index clientIndex, Index policyIndex) {
+        requireAllNonNull(clientIndex, policyIndex);
+        this.clientIndex = clientIndex;
+        this.policyIndex = policyIndex;
+    }
+    @Override
+    public CommandResult execute(Model model) throws CommandException {
+        requireNonNull(model);
+        List<Client> lastShownList = model.getFilteredClientList();
+
+        if (clientIndex.getZeroBased() >= lastShownList.size()) {
+            throw new CommandException(Messages.MESSAGE_INVALID_CLIENT_DISPLAYED_INDEX);
+        }
+
+        Client clientToDeletePolicy = lastShownList.get(clientIndex.getZeroBased());
+        // Work with titus on how to select the client that we are interested in first.
+        CommandResult cr = new SelectCommand(clientIndex).execute(model);
+
+        List<Policy> lastShownPolicyList = clientToDeletePolicy.getFilteredPolicyList();
+
+        if (policyIndex.getZeroBased() >= lastShownPolicyList.size()) {
+            throw new CommandException(Messages.MESSAGE_INVALID_POLICY_DISPLAYED_INDEX);
+        }
+
+        Policy policyToDelete = lastShownPolicyList.get(policyIndex.getZeroBased());
+        clientToDeletePolicy.getPolicyList().remove(policyToDelete);
+
+        return new CommandResult(generateSuccessMessage(clientToDeletePolicy, policyToDelete));
+    }
+
+    private String generateSuccessMessage(Client client, Policy policy) {
+        return String.format(
+            MESSAGE_DELETE_POLICY_SUCCESS, policy.toString()) + " from: "
+                + client.getName().toString();
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        if (other == this) {
+            return true;
+        }
+
+        if (!(other instanceof DeletePolicyCommand)) {
+            return false;
+        }
+
+        DeletePolicyCommand e = (DeletePolicyCommand) other;
+        return policyIndex.equals(e.policyIndex)
+                && clientIndex.equals(e.clientIndex);
+    }
+}

--- a/src/main/java/seedu/address/logic/parser/AddressBookParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddressBookParser.java
@@ -11,6 +11,7 @@ import seedu.address.logic.commands.AddPolicyCommand;
 import seedu.address.logic.commands.ClearCommand;
 import seedu.address.logic.commands.Command;
 import seedu.address.logic.commands.DeleteCommand;
+import seedu.address.logic.commands.DeletePolicyCommand;
 import seedu.address.logic.commands.EditCommand;
 import seedu.address.logic.commands.ExitCommand;
 import seedu.address.logic.commands.FindCommand;
@@ -79,6 +80,9 @@ public class AddressBookParser {
 
         case AddPolicyCommand.COMMAND_WORD:
             return new AddPolicyCommandParser().parse(arguments);
+
+        case DeletePolicyCommand.COMMAND_WORD:
+            return new DeletePolicyCommandParser().parse(arguments);
 
         case UndoCommand.COMMAND_WORD:
             return new UndoCommand();

--- a/src/main/java/seedu/address/logic/parser/CliSyntax.java
+++ b/src/main/java/seedu/address/logic/parser/CliSyntax.java
@@ -14,6 +14,7 @@ public class CliSyntax {
 
     /* Policy Prefix definitions */
     public static final Prefix PREFIX_POLICY_NAME = new Prefix("pn/");
+    public static final Prefix PREFIX_POLICY_INDEX = new Prefix("pi/");
     public static final Prefix PREFIX_POLICY_START_DATE = new Prefix("pd/");
     public static final Prefix PREFIX_POLICY_PREMIUM = new Prefix("pp/");
     public static final Prefix PREFIX_POLICY_FREQUENCY = new Prefix("pf/");

--- a/src/main/java/seedu/address/logic/parser/DeletePolicyCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/DeletePolicyCommandParser.java
@@ -1,0 +1,54 @@
+package seedu.address.logic.parser;
+
+import static java.util.Objects.requireNonNull;
+import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_POLICY_INDEX;
+
+import java.util.stream.Stream;
+
+import seedu.address.commons.core.index.Index;
+import seedu.address.commons.exceptions.IllegalValueException;
+import seedu.address.logic.commands.DeletePolicyCommand;
+import seedu.address.logic.parser.exceptions.ParseException;
+
+
+/**
+ * Parses input arguments and creates a new DeletePolicyCommand object
+ */
+public class DeletePolicyCommandParser implements Parser<DeletePolicyCommand> {
+
+    /**
+     * Parses the given {@code userInput} in the context of the DeletePolicyCommand and returns
+     * a DeletePolicyCommand object for execution.
+     * @param userInput The input that is given by the user to conduct a command.
+     * @throws ParseException if {@code userInput} does not conform the expected format
+     */
+    public DeletePolicyCommand parse(String userInput) throws ParseException {
+        requireNonNull(userInput);
+        ArgumentMultimap argMultimap = ArgumentTokenizer.tokenize(userInput, PREFIX_POLICY_INDEX);
+        Index index;
+        try {
+            index = ParserUtil.parseIndex(argMultimap.getPreamble());
+        } catch (IllegalValueException ive) {
+            throw new ParseException(
+                    String.format(MESSAGE_INVALID_COMMAND_FORMAT, DeletePolicyCommand.MESSAGE_USAGE), ive);
+        }
+        if (!arePrefixesPresent(argMultimap, PREFIX_POLICY_INDEX)
+                || argMultimap.getPreamble().isEmpty()) {
+            throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT,
+                    DeletePolicyCommand.MESSAGE_USAGE));
+        }
+
+        Index policyIndex = ParserUtil.parseIndex(argMultimap.getValue(PREFIX_POLICY_INDEX).get());
+
+        return new DeletePolicyCommand(index, policyIndex);
+    }
+
+    /**
+     * Returns true if none of the prefixes contains empty {@code Optional} values in the given
+     * {@code ArgumentMultiMap}.
+     */
+    private static boolean arePrefixesPresent(ArgumentMultimap argMultiMap, Prefix... prefixes) {
+        return Stream.of(prefixes).allMatch(prefix -> argMultiMap.getValue(prefix).isPresent());
+    }
+}

--- a/src/test/java/seedu/address/logic/commands/DeletePolicyCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/DeletePolicyCommandTest.java
@@ -1,0 +1,125 @@
+package seedu.address.logic.commands;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static seedu.address.commons.core.Messages.MESSAGE_INVALID_CLIENT_DISPLAYED_INDEX;
+import static seedu.address.commons.core.Messages.MESSAGE_INVALID_POLICY_DISPLAYED_INDEX;
+import static seedu.address.logic.commands.CommandTestUtil.assertCommandFailure;
+import static seedu.address.logic.commands.CommandTestUtil.assertCommandSuccess;
+import static seedu.address.logic.commands.CommandTestUtil.showClientAtIndex;
+import static seedu.address.testutil.TypicalClients.getTypicalAddressBook;
+import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST_CLIENT;
+import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST_POLICY;
+import static seedu.address.testutil.TypicalIndexes.INDEX_SECOND_CLIENT;
+import static seedu.address.testutil.TypicalIndexes.INDEX_SECOND_POLICY;
+
+import org.junit.jupiter.api.Test;
+
+import seedu.address.commons.core.Messages;
+import seedu.address.commons.core.index.Index;
+import seedu.address.model.Model;
+import seedu.address.model.ModelManager;
+import seedu.address.model.UserPrefs;
+import seedu.address.model.client.Client;
+import seedu.address.model.client.policy.Policy;
+
+class DeletePolicyCommandTest {
+
+    private final Model model = new ModelManager(getTypicalAddressBook(), new UserPrefs());
+    @Test
+    public void execute_validIndexUnfilteredList_success() {
+        Client client = model.getFilteredClientList().get(INDEX_FIRST_CLIENT.getZeroBased());
+        Policy policyToDelete = client.getFilteredPolicyList().get(INDEX_FIRST_POLICY.getZeroBased());
+
+        DeletePolicyCommand deletePolicyCommand = new DeletePolicyCommand(INDEX_FIRST_CLIENT, INDEX_FIRST_POLICY);
+
+        String expectedMessage = String.format(
+                DeletePolicyCommand.MESSAGE_DELETE_POLICY_SUCCESS, policyToDelete.toString()
+        ) + " from: " + client.getName().toString();
+
+        ModelManager expectedModel = new ModelManager(model.getAddressBook(), new UserPrefs());
+
+        // the model contains the same client that contains same policy list so naturally deletes the policy
+        assertCommandSuccess(deletePolicyCommand, model, expectedMessage, expectedModel);
+    }
+
+
+    @Test
+    public void execute_invalidClientIndexUnfilteredList_throwsCommandException() {
+        Index outOfBoundIndex = Index.fromOneBased(model.getFilteredClientList().size() + 1);
+        DeletePolicyCommand deletePolicyCommand = new DeletePolicyCommand(outOfBoundIndex, INDEX_FIRST_POLICY);
+
+        assertCommandFailure(deletePolicyCommand, model, MESSAGE_INVALID_CLIENT_DISPLAYED_INDEX);
+    }
+
+    @Test
+    public void execute_invalidPolicyIndexUnfilteredList_throwsCommandException() {
+        Client client = model.getFilteredClientList().get(INDEX_FIRST_CLIENT.getZeroBased());
+        Index outOfBoundIndex = Index.fromOneBased(client.getFilteredPolicyList().size() + 1);
+        DeletePolicyCommand deletePolicyCommand = new DeletePolicyCommand(INDEX_FIRST_CLIENT, outOfBoundIndex);
+
+        assertCommandFailure(deletePolicyCommand, model, MESSAGE_INVALID_POLICY_DISPLAYED_INDEX);
+    }
+
+    @Test
+    public void execute_validIndexFilteredList_success() {
+        showClientAtIndex(model, INDEX_FIRST_CLIENT);
+        Client client = model.getFilteredClientList().get(INDEX_FIRST_CLIENT.getZeroBased());
+        Policy policyToDelete = client.getFilteredPolicyList().get(INDEX_FIRST_POLICY.getZeroBased());
+
+        DeletePolicyCommand deletePolicyCommand = new DeletePolicyCommand(INDEX_FIRST_CLIENT, INDEX_FIRST_POLICY);
+
+        String expectedMessage = String.format(
+                DeletePolicyCommand.MESSAGE_DELETE_POLICY_SUCCESS, policyToDelete.toString()
+        ) + " from: " + client.getName().toString();
+
+        ModelManager expectedModel = new ModelManager(model.getAddressBook(), new UserPrefs());
+        expectedModel.updateFilteredClientList(p -> p.equals(client));
+        // the model contains the same client that contains same policy list so naturally deletes the policy
+        assertCommandSuccess(deletePolicyCommand, model, expectedMessage, expectedModel);
+    }
+
+    @Test
+    public void execute_invalidClientIndexFilteredList_throwsCommandException() {
+        showClientAtIndex(model, INDEX_FIRST_CLIENT);
+
+        Index outOfBoundIndex = INDEX_SECOND_CLIENT;
+        assertTrue(outOfBoundIndex.getZeroBased() < model.getAddressBook().getClientList().size());
+
+        DeletePolicyCommand deletePolicyCommand = new DeletePolicyCommand(outOfBoundIndex, INDEX_FIRST_POLICY);
+
+        assertCommandFailure(deletePolicyCommand, model, Messages.MESSAGE_INVALID_CLIENT_DISPLAYED_INDEX);
+    }
+
+    /*
+    Intentions on making test cases for filtered policy list, but am not sure how filtered list works in
+    client at the moment.
+     */
+
+    @Test
+    void testEquals() {
+        DeletePolicyCommand deleteFirstPolicyCommand = new DeletePolicyCommand(INDEX_FIRST_CLIENT, INDEX_FIRST_POLICY);
+        DeletePolicyCommand deleteSecondPolicyCommand = new DeletePolicyCommand(INDEX_FIRST_CLIENT,
+                INDEX_SECOND_POLICY);
+
+        assertEquals(deleteFirstPolicyCommand, deleteFirstPolicyCommand);
+
+        DeletePolicyCommand deleteFirstPolicyCommandCopy = new DeletePolicyCommand(INDEX_FIRST_CLIENT,
+                INDEX_FIRST_POLICY);
+        assertEquals(deleteFirstPolicyCommand, deleteFirstPolicyCommandCopy);
+
+
+        assertNotEquals(1, deleteFirstPolicyCommand);
+
+        // null -> returns false
+        assertNotEquals(null, deleteFirstPolicyCommand);
+
+        // different client -> returns false
+        assertNotEquals(deleteFirstPolicyCommand, deleteSecondPolicyCommand);
+
+
+        // can add more test cases that checks with different client index.
+    }
+
+}

--- a/src/test/java/seedu/address/logic/parser/DeletePolicyCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/DeletePolicyCommandParserTest.java
@@ -1,0 +1,44 @@
+package seedu.address.logic.parser;
+
+import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static seedu.address.logic.parser.CommandParserTestUtil.assertParseFailure;
+import static seedu.address.logic.parser.CommandParserTestUtil.assertParseSuccess;
+import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST_CLIENT;
+import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST_POLICY;
+
+import org.junit.jupiter.api.Test;
+
+import seedu.address.logic.commands.DeletePolicyCommand;
+
+class DeletePolicyCommandParserTest {
+
+    private DeletePolicyCommandParser parser = new DeletePolicyCommandParser();
+    @Test
+    void parse_validArgs_returnsDeletePolicyCommand() {
+        String userInput = "1 pi/1";
+        DeletePolicyCommand expectedCommand = new DeletePolicyCommand(INDEX_FIRST_CLIENT, INDEX_FIRST_POLICY);
+        assertParseSuccess(parser, userInput, expectedCommand);
+    }
+
+    @Test
+    void parse_invalidClientIndex_throwsIllegalValueException() {
+        String userInput = "a pi/1";
+        String expectedMessage = String.format(MESSAGE_INVALID_COMMAND_FORMAT, DeletePolicyCommand.MESSAGE_USAGE);
+        assertParseFailure(parser, userInput, expectedMessage);
+    }
+
+    @Test
+    void parse_missingPolicyIndex_throwsParseException() {
+        String userInput = "a 1";
+        String expectedMessage = String.format(MESSAGE_INVALID_COMMAND_FORMAT, DeletePolicyCommand.MESSAGE_USAGE);
+        assertParseFailure(parser, userInput, expectedMessage);
+    }
+
+    @Test
+    void parse_missingClientIndex_throwsParseException() {
+        String userInput = "pi/1";
+        String expectedMessage = String.format(MESSAGE_INVALID_COMMAND_FORMAT, DeletePolicyCommand.MESSAGE_USAGE);
+        assertParseFailure(parser, userInput, expectedMessage);
+    }
+
+}

--- a/src/test/java/seedu/address/testutil/TypicalIndexes.java
+++ b/src/test/java/seedu/address/testutil/TypicalIndexes.java
@@ -9,4 +9,10 @@ public class TypicalIndexes {
     public static final Index INDEX_FIRST_CLIENT = Index.fromOneBased(1);
     public static final Index INDEX_SECOND_CLIENT = Index.fromOneBased(2);
     public static final Index INDEX_THIRD_CLIENT = Index.fromOneBased(3);
+
+    public static final Index INDEX_FIRST_POLICY = Index.fromOneBased(1);
+
+    public static final Index INDEX_SECOND_POLICY = Index.fromOneBased(2);
+
+    public static final Index INDEX_THIRD_POLICY = Index.fromOneBased(3);
 }


### PR DESCRIPTION
* Fix `AddPolicyCommand` MESSAGE_USAGE to be neat so user can understand error messages clearly
* Add `DeletePolicyCommand` to allow users to delete a policy that is associated to the user
* Add `DeletePolicyCommandParser` to parse user input to create a `DeletePolicyCommand` with the format being "deletePolicy <client_index> pi/<policy_index>" eg; deletePolicy 1 pi/1
* Add test cases for `DeletePolicyCommand` and `DeletePolicyCommandParser`

Goals:
* Associate `SelectCommand` so that the user can directly be shown the client that is he interested in deleting a policy from
* Understand and perhaps implement FilteredList for `Policy` based on the understanding from `Client` FilteredList
* Add more test cases for DeletePolicyCommand and DeletePolicyCommandParser